### PR TITLE
Various demo updates/upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <properties>
         <confluent.version>8.0.0</confluent.version>
         <kafka.version>4.0.0</kafka.version>
+        <jackson.version>2.17.3</jackson.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <maven.compiler.source>8</maven.compiler.source>
@@ -37,6 +38,17 @@
         <schema.registry.url>http://localhost:8081</schema.registry.url>
         <schema.registry.basic.auth.user.info></schema.registry.basic.auth.user.info>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <confluent.version>7.4.2-0</confluent.version>
-        <kafka.version>3.4.0</kafka.version>
+        <confluent.version>8.0.0</confluent.version>
+        <kafka.version>4.0.0</kafka.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <maven.compiler.source>8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
                                     <mode>WRITE</mode>
                                     <expr>message.totalPriceCents > 0</expr>
                                     <params>
-                                        <dlq.topic>bad_orders</dlq.topic>
+                                        <dlq.topic>orders-dlq</dlq.topic>
                                     </params>
                                     <onFailure>DLQ</onFailure>
                                     <disabled>false</disabled>

--- a/src/main/java/io/confluent/data/contracts/OrderGen.java
+++ b/src/main/java/io/confluent/data/contracts/OrderGen.java
@@ -12,7 +12,7 @@ public class OrderGen {
     return new Order(
         fake.number().numberBetween(1, 10000),
         fake.number().numberBetween(1, 10000),
-        fake.number().numberBetween(1, 10000),
+        fake.number().numberBetween(-1000, 10000),
         OrderStatus.Pending,
         Instant.now()
     );

--- a/src/main/java/io/confluent/data/contracts/ProducerApp.java
+++ b/src/main/java/io/confluent/data/contracts/ProducerApp.java
@@ -34,6 +34,7 @@ public class ProducerApp implements Runnable {
 
       // Create the topic if it doesn't exist already
       ClientUtils.createTopic(props, topic);
+      ClientUtils.createTopic(props, topic + "-dlq");
 
     } catch (Exception e) {
       log.error("Error in ProducerApp.constructor", e);

--- a/src/main/java/io/confluent/data/contracts/ProducerApp.java
+++ b/src/main/java/io/confluent/data/contracts/ProducerApp.java
@@ -45,18 +45,20 @@ public class ProducerApp implements Runnable {
   public void run() {
     try (Producer<String, Object> producer = new KafkaProducer<>(props)) {
       while (true) {
-        // Create a producer record
-        ProducerRecord<String, Object> record = new ProducerRecord<>(topic, OrderGen.getNewOrder());
+        try {
+          // Create a producer record
+          ProducerRecord<String, Object> record = new ProducerRecord<>(topic, OrderGen.getNewOrder());
 
-        // Send the record
-        producer.send(record);
+          // Send the record
+          producer.send(record);
 
-        System.out.println("New order: " + record.value());
+          System.out.println("New order: " + record.value());
 
-        Thread.sleep(1000);
+          Thread.sleep(1000);
+        } catch (Exception e) {
+          log.error("Error in ProducerApp.run", e);
+        }
       }
-    } catch (Exception e) {
-      log.error("Error in ProducerApp.run", e);
     }
   }
 


### PR DESCRIPTION
I exercised this demo and found the following changes I needed to make:

- CP version upgrade to 8.0.0
- Locked Jackson version.  Without this I got a bunch of classloader related problems from floating/different-version dependencies with conflicts from several things that depend on Jackson.
- Changes the DLQ topic name.  This hasn't been done perfectly because I have to repeat myself as I didn't template the value in `pom.xml` where the DQ Rule is defined.  Also the demo failed for me if the DLQ topic was not pre-created - perhaps other Kafka clusters had auto-create on ... but the `orders` topic is explicitly created in the code so I copied this for DLQ topic.
- Code as I found it did not trigger any failures, so no DLQ production.  I changed the random record code so that the producer would sometimes generate records with negative `totalPriceCents` to cause a rule-failure and DLQ.
- Once DLQ records are produced, the first one was killing the producer due to not catching the expection thrown by the DLQ rule handler.  So I reworked the producer exception handling so it can continue, which is what you might expect when DLQing bad records.